### PR TITLE
ci: Add permissions block to release-please workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Gabriel-Rockson/shallowdepth/security/code-scanning/1](https://github.com/Gabriel-Rockson/shallowdepth/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the `google-github-actions/release-please-action` to function correctly. Based on typical usage of release automation tools, the workflow likely requires `contents: write` to create releases and update repository contents. If additional permissions are required, they should be added explicitly after reviewing the action's documentation.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`release-please`) to limit permissions to that job only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
